### PR TITLE
Update default alias

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -32,7 +32,7 @@ const sortSearchByDistance = false;
 //
 // In a way, 'processAlias' defines which transaction process (or processes)
 // this particular web application is able to handle.
-const bookingProcessAlias = 'sca-preauth-nightly-booking/release-1';
+const bookingProcessAlias = 'preauth-nightly-booking/release-1';
 
 // The transaction line item code for the main unit type in bookings.
 //


### PR DESCRIPTION
Update default alias to match the one that is used by default for new marketplaces.