### PR TITLE
Use Client ID in subdomain

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/server/index.js
+++ b/server/index.js
@@ -168,7 +168,7 @@ app.get('*', (req, res) => {
   const clientId = hostnameToClientId(req.hostname);
 
   if (!clientId) {
-    return res.status(404).send("Invalid Client ID format.");
+    return res.status(404).send('Invalid Client ID format.');
   }
 
   // Get handle to tokenStore

--- a/src/components/Page/Page.js
+++ b/src/components/Page/Page.js
@@ -46,12 +46,17 @@ class PageComponent extends Component {
     document.addEventListener('drop', preventDefault);
 
     const intercomData = this.getIntercomData();
-    window.Intercom('boot', intercomData);
+
+    if (window.Intercom) {
+      window.Intercom('boot', intercomData);
+    }
   }
 
   componentDidUpdate() {
     const intercomData = this.getIntercomData();
-    window.Intercom('update', intercomData);
+    if (window.Intercom) {
+      window.Intercom('update', intercomData);
+    }
   }
 
   getIntercomData = () => {

--- a/src/components/Topbar/Topbar.js
+++ b/src/components/Topbar/Topbar.js
@@ -115,7 +115,7 @@ class TopbarComponent extends Component {
       const path = pathByRouteName('LandingPage', routeConfiguration());
 
       // Shutdown Intercom
-      if (typeof window !== 'undefined') {
+      if (typeof window !== 'undefined' && window.Intercom) {
         window.Intercom('shutdown');
         window.Intercom('boot', { app_id: process.env.REACT_APP_INTERCOM_APP_ID });
       }

--- a/src/config.js
+++ b/src/config.js
@@ -56,9 +56,22 @@ const dayCountAvailableForBooking = 90;
 // script, react-scripts (and the sharetribe-scripts fork of
 // react-scripts) require using the REACT_APP_ prefix to avoid
 // exposing server secrets to the client side.
-const sdkClientId = process.env.REACT_APP_SHARETRIBE_SDK_CLIENT_ID;
+// const sdkClientId = process.env.REACT_APP_SHARETRIBE_SDK_CLIENT_ID;
 const sdkBaseUrl = process.env.REACT_APP_SHARETRIBE_SDK_BASE_URL;
 const sdkTransitVerbose = process.env.REACT_APP_SHARETRIBE_SDK_TRANSIT_VERBOSE === 'true';
+
+const hostnameToClientId = hostname => {
+  // Match the first sub domain for an UUID in form:
+  // 00000000-0000-0000-0000-000000000000.another-sub-domain.example.com
+  const match = /^(\w{8}-\w{4}-\w{4}-\w{4}-\w{12})\./.exec(hostname);
+  return match ? match[1] : null;
+};
+
+let sdkClientId;
+
+if (typeof window !== 'undefined') {
+  sdkClientId = hostnameToClientId(window.location.hostname);
+}
 
 const currency = process.env.REACT_APP_SHARETRIBE_MARKETPLACE_CURRENCY;
 
@@ -83,7 +96,13 @@ const postalCode = '00100';
 const streetAddress = 'Bulevardi 14';
 
 // Canonical root url is needed in social media sharing and SEO optimization purposes.
-const canonicalRootURL = process.env.REACT_APP_CANONICAL_ROOT_URL;
+// const canonicalRootURL = process.env.REACT_APP_CANONICAL_ROOT_URL;
+
+let canonicalRootURL;
+
+if (typeof window !== 'undefined') {
+  canonicalRootURL = window.location.origin;
+}
 
 // Site title is needed in meta tags (bots and social media sharing reads those)
 const siteTitle = 'Saunatime Demo';

--- a/src/containers/AuthenticationPage/__snapshots__/AuthenticationPage.test.js.snap
+++ b/src/containers/AuthenticationPage/__snapshots__/AuthenticationPage.test.js.snap
@@ -12,6 +12,10 @@ exports[`AuthenticationPageComponent matches snapshot 1`] = `
   scrollingDisabled={false}
   title="AuthenticationPage.schemaTitleLogin"
 >
+  <TopbarNotification
+    className={null}
+    rootClassName={null}
+  />
   <LayoutSingleColumn
     className={null}
     rootClassName={null}

--- a/src/containers/ContactDetailsPage/__snapshots__/ContactDetailsPage.test.js.snap
+++ b/src/containers/ContactDetailsPage/__snapshots__/ContactDetailsPage.test.js.snap
@@ -5,6 +5,10 @@ exports[`ContactDetailsPage matches snapshot 1`] = `
   scrollingDisabled={false}
   title="ContactDetailsPage.title"
 >
+  <TopbarNotification
+    className={null}
+    rootClassName={null}
+  />
   <LayoutSideNavigation
     className={null}
     containerClassName={null}

--- a/src/containers/InboxPage/__snapshots__/InboxPage.test.js.snap
+++ b/src/containers/InboxPage/__snapshots__/InboxPage.test.js.snap
@@ -5,6 +5,10 @@ exports[`InboxPage matches snapshot 1`] = `
   scrollingDisabled={false}
   title="InboxPage.ordersTitle"
 >
+  <TopbarNotification
+    className={null}
+    rootClassName={null}
+  />
   <LayoutSideNavigation
     className={null}
     containerClassName={null}
@@ -463,6 +467,10 @@ exports[`InboxPage matches snapshot 3`] = `
   scrollingDisabled={false}
   title="InboxPage.salesTitle"
 >
+  <TopbarNotification
+    className={null}
+    rootClassName={null}
+  />
   <LayoutSideNavigation
     className={null}
     containerClassName={null}

--- a/src/containers/LandingPage/__snapshots__/LandingPage.test.js.snap
+++ b/src/containers/LandingPage/__snapshots__/LandingPage.test.js.snap
@@ -19,7 +19,7 @@ exports[`LandingPage matches snapshot 1`] = `
       "@type": "WebPage",
       "description": "LandingPage.schemaDescription",
       "image": Array [
-        "http://localhost:3000saunatimeFacebook-1200x630.jpg",
+        "http://localhostsaunatimeFacebook-1200x630.jpg",
       ],
       "name": "LandingPage.schemaTitle",
     }
@@ -30,12 +30,16 @@ exports[`LandingPage matches snapshot 1`] = `
     Array [
       Object {
         "height": 314,
-        "url": "http://localhost:3000saunatimeTwitter-600x314.jpg",
+        "url": "http://localhostsaunatimeTwitter-600x314.jpg",
         "width": 600,
       },
     ]
   }
 >
+  <TopbarNotification
+    className={null}
+    rootClassName={null}
+  />
   <LayoutSingleColumn
     className={null}
     rootClassName={null}

--- a/src/containers/ManageListingsPage/__snapshots__/ManageListingsPage.test.js.snap
+++ b/src/containers/ManageListingsPage/__snapshots__/ManageListingsPage.test.js.snap
@@ -5,6 +5,10 @@ exports[`ContactDetailsPage matches snapshot 1`] = `
   scrollingDisabled={false}
   title="ManageListingsPage.title"
 >
+  <TopbarNotification
+    className={null}
+    rootClassName={null}
+  />
   <LayoutSingleColumn
     className={null}
     rootClassName={null}

--- a/src/containers/NotFoundPage/__snapshots__/NotFoundPage.test.js.snap
+++ b/src/containers/NotFoundPage/__snapshots__/NotFoundPage.test.js.snap
@@ -5,6 +5,10 @@ exports[`NotFoundPageComponent matches snapshot 1`] = `
   scrollingDisabled={false}
   title="NotFoundPage.title"
 >
+  <TopbarNotification
+    className={null}
+    rootClassName={null}
+  />
   <LayoutSingleColumn
     className={null}
     rootClassName={null}

--- a/src/containers/PasswordChangePage/__snapshots__/PasswordChangePage.test.js.snap
+++ b/src/containers/PasswordChangePage/__snapshots__/PasswordChangePage.test.js.snap
@@ -5,6 +5,10 @@ exports[`PasswordChangePage matches snapshot 1`] = `
   scrollingDisabled={false}
   title="PasswordChangePage.title"
 >
+  <TopbarNotification
+    className={null}
+    rootClassName={null}
+  />
   <LayoutSideNavigation
     className={null}
     containerClassName={null}

--- a/src/containers/PasswordRecoveryPage/__snapshots__/PasswordRecoveryPage.test.js.snap
+++ b/src/containers/PasswordRecoveryPage/__snapshots__/PasswordRecoveryPage.test.js.snap
@@ -5,6 +5,10 @@ exports[`ContactDetailsPage matches snapshot 1`] = `
   scrollingDisabled={false}
   title="PasswordRecoveryPage.title"
 >
+  <TopbarNotification
+    className={null}
+    rootClassName={null}
+  />
   <LayoutSingleColumn
     className={null}
     rootClassName={null}

--- a/src/containers/PayoutPreferencesPage/__snapshots__/PayoutPreferencesPage.test.js.snap
+++ b/src/containers/PayoutPreferencesPage/__snapshots__/PayoutPreferencesPage.test.js.snap
@@ -5,6 +5,10 @@ exports[`PayoutPreferencesPage matches snapshot with Stripe connected 1`] = `
   scrollingDisabled={false}
   title="PayoutPreferencesPage.title"
 >
+  <TopbarNotification
+    className={null}
+    rootClassName={null}
+  />
   <LayoutSideNavigation
     className={null}
     containerClassName={null}
@@ -60,6 +64,10 @@ exports[`PayoutPreferencesPage matches snapshot with Stripe not connected 1`] = 
   scrollingDisabled={false}
   title="PayoutPreferencesPage.title"
 >
+  <TopbarNotification
+    className={null}
+    rootClassName={null}
+  />
   <LayoutSideNavigation
     className={null}
     containerClassName={null}
@@ -130,6 +138,10 @@ exports[`PayoutPreferencesPage matches snapshot with details submitted 1`] = `
   scrollingDisabled={false}
   title="PayoutPreferencesPage.title"
 >
+  <TopbarNotification
+    className={null}
+    rootClassName={null}
+  />
   <LayoutSideNavigation
     className={null}
     containerClassName={null}

--- a/src/containers/ProfilePage/__snapshots__/ProfilePage.test.js.snap
+++ b/src/containers/ProfilePage/__snapshots__/ProfilePage.test.js.snap
@@ -12,6 +12,10 @@ exports[`ProfilePage matches snapshot 1`] = `
   scrollingDisabled={false}
   title="ProfilePage.schemaTitle"
 >
+  <TopbarNotification
+    className={null}
+    rootClassName={null}
+  />
   <LayoutSideNavigation
     className={null}
     containerClassName={null}

--- a/src/containers/ProfileSettingsPage/__snapshots__/ProfileSettingsPage.test.js.snap
+++ b/src/containers/ProfileSettingsPage/__snapshots__/ProfileSettingsPage.test.js.snap
@@ -5,6 +5,10 @@ exports[`ContactDetailsPage matches snapshot 1`] = `
   scrollingDisabled={false}
   title="ProfileSettingsPage.title"
 >
+  <TopbarNotification
+    className={null}
+    rootClassName={null}
+  />
   <LayoutSingleColumn
     className={null}
     rootClassName={null}

--- a/src/containers/TransactionPage/__snapshots__/TransactionPage.test.js.snap
+++ b/src/containers/TransactionPage/__snapshots__/TransactionPage.test.js.snap
@@ -5,6 +5,10 @@ exports[`TransactionPage - Order matches snapshot 1`] = `
   scrollingDisabled={false}
   title="TransactionPage.title"
 >
+  <TopbarNotification
+    className={null}
+    rootClassName={null}
+  />
   <LayoutSingleColumn
     className={null}
     rootClassName={null}
@@ -229,6 +233,10 @@ exports[`TransactionPage - Sale matches snapshot 1`] = `
   scrollingDisabled={false}
   title="TransactionPage.title"
 >
+  <TopbarNotification
+    className={null}
+    rootClassName={null}
+  />
   <LayoutSingleColumn
     className={null}
     rootClassName={null}


### PR DESCRIPTION
This PR changes the demo to dynamically use a Client ID from the first sub domain in form:

https://00000000-0000-0000-0000-000000000000.another-sub-domain.example.com

This allows us to deploy a single demo where the URL defines which marketplace is used for the Marketplace API calls.

The canonical URL is also taken from the window URL dynamically. This PR also disables the sitemap (used the canonical URL in the server) and disallows all robots from crawling the demo site.