### PR TITLE
Whitelist more pages for email verification modal

### DIFF
--- a/src/components/ModalMissingInformation/ModalMissingInformation.js
+++ b/src/components/ModalMissingInformation/ModalMissingInformation.js
@@ -19,6 +19,20 @@ const MISSING_INFORMATION_MODAL_WHITELIST = [
   'EmailVerificationPage',
   'PasswordResetPage',
   'StripePayoutPage',
+
+  // Whitelisted only in demo:
+  'PaymentMethodsPage',
+  'AboutPage',
+  'SearchPage',
+  'SearchFiltersPage',
+  'SearchListingsPage',
+  'SearchMapPage',
+  'ProfileSettingsPage',
+  'ManageListingsPage',
+  'AccountSettingsPage',
+  'ContactDetailsPage',
+  'PasswordResetPage',
+  'LandingPage',
 ];
 
 const EMAIL_VERIFICATION = 'EMAIL_VERIFICATION';


### PR DESCRIPTION
In the demo, we want to have more pages whitelisted for `ModalMissingInformation`. After these changes the modal will be visible on the following pages:
- InboxPage 
- ListingPage 
- EditListingWizard 
- ProfilePage 


