### PR TITLE
Prefill Stripe Connect Onboarding

### DIFF
--- a/src/components/EditListingWizard/EditListingWizard.js
+++ b/src/components/EditListingWizard/EditListingWizard.js
@@ -248,8 +248,16 @@ class EditListingWizard extends Component {
   }
 
   handlePayoutSubmit(values) {
+    // For demo customization, we need to add useDefaultTestData
+    // and currentUser to values we pass to onPayoutDetailsSubmit
+    // function to prefill some fields in Stripe Connect Onboarding
+    const useDefaultTestData = this.state.useDefaultTestData;
+    const currentUser = this.props.currentUser;
+
     this.props
-      .onPayoutDetailsSubmit(values)
+      .onPayoutDetailsSubmit(
+        this.state.useDefaultTestData ? { values, useDefaultTestData, currentUser } : values
+      )
       .then(response => {
         this.props.onManageDisableScrolling('EditListingWizard.payoutModal', false);
       })

--- a/src/ducks/stripeConnectAccount.duck.js
+++ b/src/ducks/stripeConnectAccount.duck.js
@@ -171,10 +171,27 @@ export const createStripeAccount = params => (dispatch, getState, sdk) => {
   // In Flex both 'card_payments' and 'transfers' are required.
   const requestedCapabilities = ['card_payments', 'transfers'];
 
-  const accountInfo = {
+  // Demo customization starts
+  let accountInfo = {
     business_type: accountType,
     tos_shown_and_accepted: true,
   };
+
+  const { useDefaultTestData, currentUser } = params;
+
+  if (useDefaultTestData) {
+    accountInfo = {
+      ...accountInfo,
+      individual: {
+        first_name: currentUser.attributes.profile.firstName,
+        last_name: currentUser.attributes.profile.lastName,
+        email: currentUser.attributes.email,
+        address: config.stripe.testData.providerAddress,
+      },
+    };
+  }
+
+  // Demo customization ends
 
   dispatch(stripeAccountCreateRequest());
 

--- a/src/forms/StripeConnectAccountForm/StripeConnectAccountForm.js
+++ b/src/forms/StripeConnectAccountForm/StripeConnectAccountForm.js
@@ -224,10 +224,17 @@ const StripeConnectAccountFormComponent = props => {
   const { onSubmit, ...restOfProps } = props;
   const isUpdate = props.stripeConnected;
 
+  // For demo customization, we need to add useDefaultTestData
+  // and currentUser to values we pass to onPayoutDetailsSubmit
+  // function to prefill some fields in Stripe Connect Onboarding
+  const { currentUser, useDefaultTestData } = props;
+  const handleOnSubmitInDemo = values =>
+    onSubmit({ ...values, currentUser, useDefaultTestData }, isUpdate);
+
   return (
     <FinalForm
       {...restOfProps}
-      onSubmit={values => onSubmit(values, isUpdate)}
+      onSubmit={values => handleOnSubmitInDemo(values)}
       mutators={{
         ...arrayMutators,
       }}
@@ -251,8 +258,6 @@ const StripeConnectAccountFormComponent = props => {
           form,
           values,
           stripeConnected,
-          currentUser,
-          useDefaultTestData,
         } = fieldRenderProps;
 
         const accountDataLoaded = stripeConnected && stripeAccountFetched && savedCountry;

--- a/src/stripe-config.js
+++ b/src/stripe-config.js
@@ -366,6 +366,11 @@ export const testData = {
   country: 'FI',
   bankAccountNumber: 'FI89370400440532013000',
   bankAccountType: 'iban',
+  providerAddress: {
+    line1: 'Marketplace Street 123',
+    postal_code: '00100',
+    city: 'Helsinki',
+  },
 };
 
 /*


### PR DESCRIPTION
To make onboarding flow smoother, we can use some test data to prefill Stripe Connect Onboarding. We will prefill the user's name, email, and address there based on the currentUser and address stored in stripe-config.js. Stripe Connect Onboarding is prefilled with test data when the user has chosen to use test data for creating the Stripe Account. 

After this change, the fields users need to fill in are the date of birth and phone number. 

<img width="528" alt="Screenshot 2021-02-15 at 9 26 27" src="https://user-images.githubusercontent.com/9502221/107917469-a6c6d180-6f70-11eb-9810-f23724aa285a.png">
