### PR TITLE
Improvements for adding the Intercom tours to demo

### DIFF
--- a/DEMO_CHANGELOG.md
+++ b/DEMO_CHANGELOG.md
@@ -5,6 +5,11 @@ This file contains changes that are made solely to the demo FTW.
 
 ---
 
+## 2021-03-03
+
+- [add] Add new Intercom custom attribute Flex_demo_client_id, remove email verification modal
+  completely and small improvements to CSP [#29](https://github.com/sharetribe/ftw-demo/pull/29)
+
 ## 2021-02-19
 
 - [fix] Fix using stored payment card after adding the Stripe test buttons

--- a/server/csp.js
+++ b/server/csp.js
@@ -95,6 +95,8 @@ module.exports = (reportUri, enforceSsl, reportOnly) => {
   const { connectSrc = [self] } = defaultDirectives;
   const { scriptSrc = [self] } = defaultDirectives;
   const { fontSrc = [self] } = defaultDirectives;
+  const { imgSrc = [self] } = defaultDirectives;
+  const { mediaSrc = [self] } = defaultDirectives;
 
   const intercom = ['*.intercomcdn.com/', '*.intercom.io/', '*.intercomassets.com/'];
 
@@ -102,6 +104,8 @@ module.exports = (reportUri, enforceSsl, reportOnly) => {
   const intercomConnect = connectSrc.concat('*.intercom.io/', 'wss://*.intercom.io');
   const intercomFont = fontSrc.concat('*.intercomcdn.com/');
 
+  const intercomImages = imgSrc.concat('*.intercomassets.com/');
+  const intercomMedia = mediaSrc.concat('*.intercomcdn.com');
   const customConnectSrc = intercomConnect.concat('*.sentry.io');
 
   const customDirectives = {
@@ -110,6 +114,8 @@ module.exports = (reportUri, enforceSsl, reportOnly) => {
     scriptSrc: intercomScripts,
     connectSrc: customConnectSrc,
     fontSrc: intercomFont,
+    imgSrc: intercomImages,
+    mediaSrc: intercomMedia,
   };
 
   // ================ END CUSTOM CSP URLs ================ //

--- a/src/components/Page/Page.js
+++ b/src/components/Page/Page.js
@@ -67,8 +67,20 @@ class PageComponent extends Component {
     }
   }
 
+  hostnameToClientId = hostname => {
+    // Match the first sub domain for an UUID in form:
+    // 00000000-0000-0000-0000-000000000000.another-sub-domain.example.com
+    const match = /^(\w{8}-\w{4}-\w{4}-\w{4}-\w{12})\./.exec(hostname);
+    return match ? match[1] : null;
+  };
+
   getIntercomData = () => {
     const { isAuthenticated, currentUser } = this.props;
+    const hostname = typeof window !== 'undefined' ? window.location.hostname : null;
+    const clientId = hostname ? this.hostnameToClientId(hostname) : null;
+
+    const clientIdMaybe = clientId ? { Flex_demo_client_id: clientId } : null;
+
     const userInfoMaybe =
       isAuthenticated && currentUser
         ? {
@@ -80,6 +92,7 @@ class PageComponent extends Component {
     const data = {
       app_id: process.env.REACT_APP_INTERCOM_APP_ID,
       ...userInfoMaybe,
+      ...clientIdMaybe,
       Flex_demo: true,
     };
 

--- a/src/components/Topbar/Topbar.js
+++ b/src/components/Topbar/Topbar.js
@@ -15,7 +15,6 @@ import {
   LimitedAccessBanner,
   Logo,
   Modal,
-  ModalMissingInformation,
   NamedLink,
   TopbarDesktop,
   TopbarMobileMenu,
@@ -270,19 +269,6 @@ class TopbarComponent extends Component {
             </p>
           </div>
         </Modal>
-        <ModalMissingInformation
-          id="MissingInformationReminder"
-          containerClassName={css.missingInformationModal}
-          currentUser={currentUser}
-          currentUserHasListings={currentUserHasListings}
-          currentUserHasOrders={currentUserHasOrders}
-          location={location}
-          onManageDisableScrolling={onManageDisableScrolling}
-          onResendVerificationEmail={onResendVerificationEmail}
-          sendVerificationEmailInProgress={sendVerificationEmailInProgress}
-          sendVerificationEmailError={sendVerificationEmailError}
-        />
-
         <GenericError show={showGenericError} />
       </div>
     );


### PR DESCRIPTION
- Remove email verificaiton modal (ModalMissingInformation) completely
- Add new Intercom custom attribute Flex_demo_client_id which is needed in Intercom to point the Intercom tour to correct demo URL dynamically
- Update CSP a bit more (some missing Intercom paths)