### PR TITLE
Update v10.1.0 from upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,20 @@ way to update this template, but currently, we follow a pattern:
 
 ---
 
-## Upcoming version 2022-XX-XX
+## Upcoming version 2023-XX-XX
+
+## [v10.1.0] 2023-02-28
+
+- [change] remove background-color from images (to allow opacity).
+  [#1590](https://github.com/sharetribe/ftw-daily/pull/1590)
+- [change] improve error handling possibilities on PageBuilder.
+  [#1589](https://github.com/sharetribe/ftw-daily/pull/1589)
+- [fix] AuthenticationPage.duck.js: had wrong asset name.
+  [#1588](https://github.com/sharetribe/ftw-daily/pull/1588)
+- [change] P.js: remove requirement for mandatory children.
+  [#1587](https://github.com/sharetribe/ftw-daily/pull/1587)
+
+  [v10.1.0]: https://github.com/sharetribe/ftw-daily/compare/v10.0.0.../v10.1.0
 
 ## [v10.0.0] 2023-02-14
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {

--- a/src/containers/AuthenticationPage/AuthenticationPage.duck.js
+++ b/src/containers/AuthenticationPage/AuthenticationPage.duck.js
@@ -2,6 +2,6 @@ import { fetchPageAssets } from '../../ducks/hostedAssets.duck';
 export const ASSET_NAME = 'terms-of-service';
 
 export const loadData = (params, search) => dispatch => {
-  const pageAsset = { termsOfServicePage: `content/pages/${ASSET_NAME}.json` };
+  const pageAsset = { termsOfService: `content/pages/${ASSET_NAME}.json` };
   return dispatch(fetchPageAssets(pageAsset, true));
 };

--- a/src/containers/LandingPage/FallbackPage.js
+++ b/src/containers/LandingPage/FallbackPage.js
@@ -4,11 +4,13 @@ import PageBuilder from '../PageBuilder/PageBuilder';
 import css from './FallbackPage.module.css';
 
 // Create fallback content (array of sections) in page asset format:
-export const fallbackSections = {
+export const fallbackSections = error => ({
   sections: [
     {
       sectionType: 'customMaintenance',
       sectionId: 'maintenance-mode',
+      // pass possible error to SectionMaintenanceMode component
+      error,
     },
   ],
   meta: {
@@ -21,45 +23,56 @@ export const fallbackSections = {
       content: 'Home page fetch failed',
     },
   },
-};
+});
 
 // Note: this microcopy/translation does not come from translation file.
 //       It needs to be something that is not part of fetched assets but built-in text
 const SectionMaintenanceMode = props => {
-  const { sectionId } = props;
+  const { sectionId, error } = props;
+  // 404 means that the landing-page asset was not found from the expected asset path
+  // which is defined in config.js
+  const is404 = error?.status === 404;
 
   return (
     <section id={sectionId} className={css.root}>
-      <div className={css.content}>
-        <h1>You need to add a landing page to your demo marketplace </h1>
-        <p>
-          The landing page of your Flex Demo Marketplace is now powered by Pages, which allows you
-          to manage your static content pages without coding in Console. To refresh your Demo
-          Marketplace, you need to go to Pages in your Flex Console and click the button “Import
-          default pages”. You can then make adjustments to your Demo Marketplace and see how they
-          look on the page.
-        </p>
-        <p>
-          <ExternalLink href="https://flex-console.sharetribe.com/a/content/pages">
-            Go to Pages in Console
-          </ExternalLink>
-        </p>
-      </div>
+      {is404 ? (
+        <div className={css.content}>
+          <h2>You need to add a landing page to your demo marketplace</h2>
+          <p>
+            The landing page of your Flex Demo Marketplace is now powered by Pages, which allows you
+            to manage your static content pages without coding in Console. To refresh your Demo
+            Marketplace, you need to go to Pages in your Flex Console and click the button “Import
+            default pages”. You can then make adjustments to your Demo Marketplace and see how they
+            look on the page.
+          </p>
+          <p>
+            <ExternalLink href="https://flex-console.sharetribe.com/a/content/pages">
+              Go to Pages in Console
+            </ExternalLink>
+          </p>
+        </div>
+      ) : (
+        <div className={css.content}>
+          <h2>Oops, something went wrong!</h2>
+          <p>{error?.message}</p>
+        </div>
+      )}
     </section>
   );
 };
 
 // This is the fallback page, in case there's no Landing Page asset defined in Console.
 const FallbackPage = props => {
+  const { error, ...rest } = props;
   return (
     <PageBuilder
-      pageAssetsData={fallbackSections}
+      pageAssetsData={fallbackSections(error)}
       options={{
         sectionComponents: {
           customMaintenance: { component: SectionMaintenanceMode },
         },
       }}
-      {...props}
+      {...rest}
     />
   );
 };

--- a/src/containers/LandingPage/LandingPage.js
+++ b/src/containers/LandingPage/LandingPage.js
@@ -2,10 +2,9 @@ import React from 'react';
 import { bool, object } from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 
-import { injectIntl, intlShape } from '../../util/reactIntl';
 import { camelize } from '../../util/string';
+import { propTypes } from '../../util/types';
 
 import PageBuilder from '../../containers/PageBuilder/PageBuilder';
 
@@ -13,27 +12,27 @@ import FallbackPage from './FallbackPage';
 import { ASSET_NAME } from './LandingPage.duck';
 
 export const LandingPageComponent = props => {
-  const { pageAssetsData, inProgress } = props;
+  const { pageAssetsData, inProgress, error } = props;
 
   return (
     <PageBuilder
       pageAssetsData={pageAssetsData?.[camelize(ASSET_NAME)]?.data}
       inProgress={inProgress}
-      fallbackPage={<FallbackPage />}
+      error={error}
+      fallbackPage={<FallbackPage error={error} />}
     />
   );
 };
 
 LandingPageComponent.propTypes = {
-  // from injectIntl
-  intl: intlShape.isRequired,
   pageAssetsData: object,
   inProgress: bool,
+  error: propTypes.error,
 };
 
 const mapStateToProps = state => {
-  const { pageAssetsData, inProgress } = state.hostedAssets || {};
-  return { pageAssetsData, inProgress };
+  const { pageAssetsData, inProgress, error } = state.hostedAssets || {};
+  return { pageAssetsData, inProgress, error };
 };
 
 // Note: it is important that the withRouter HOC is **outside** the
@@ -42,10 +41,6 @@ const mapStateToProps = state => {
 // lifecycle hook.
 //
 // See: https://github.com/ReactTraining/react-router/issues/4671
-const LandingPage = compose(
-  withRouter,
-  connect(mapStateToProps),
-  injectIntl
-)(LandingPageComponent);
+const LandingPage = compose(connect(mapStateToProps))(LandingPageComponent);
 
 export default LandingPage;

--- a/src/containers/PageBuilder/BlockBuilder/BlockDefault/BlockDefault.module.css
+++ b/src/containers/PageBuilder/BlockBuilder/BlockDefault/BlockDefault.module.css
@@ -3,7 +3,6 @@
 
 .media {
   width: 100%;
-  background-color: var(--matterColorNegative); /* Loading state color for the images */
   border-radius: 8px;
   margin-bottom: 0;
 }

--- a/src/containers/PageBuilder/PageBuilder.js
+++ b/src/containers/PageBuilder/PageBuilder.js
@@ -74,9 +74,17 @@ const getMetadata = (meta, schemaType, fieldOptions) => {
  * @returns page component
  */
 const PageBuilder = props => {
-  const { pageAssetsData, inProgress, fallbackPage, schemaType, options, ...pageProps } = props;
+  const {
+    pageAssetsData,
+    inProgress,
+    error,
+    fallbackPage,
+    schemaType,
+    options,
+    ...pageProps
+  } = props;
 
-  if (!pageAssetsData && fallbackPage && !inProgress) {
+  if (!pageAssetsData && fallbackPage && !inProgress && error) {
     return fallbackPage;
   }
 

--- a/src/containers/PageBuilder/Primitives/Image/Image.js
+++ b/src/containers/PageBuilder/Primitives/Image/Image.js
@@ -40,7 +40,7 @@ export const FieldImage = React.forwardRef((props, ref) => {
   const firstImageVariant = variants[variantNames[0]];
   const { width: aspectWidth, height: aspectHeight } = firstImageVariant || {};
 
-  const classes = classNames(rootClassName || css.markdownImage, className);
+  const classes = classNames(rootClassName || css.fieldImage, className);
   return (
     <AspectRatioWrapper className={classes} width={aspectWidth || 1} height={aspectHeight || 1}>
       <ResponsiveImage

--- a/src/containers/PageBuilder/Primitives/Image/Image.module.css
+++ b/src/containers/PageBuilder/Primitives/Image/Image.module.css
@@ -1,5 +1,9 @@
 .markdownImage {
-  width: 100%;
+  /**
+   * Note: markdown images might be too small for filling the space.
+   */
+  width: auto;
+  max-width: 100%;
   border-radius: 8px;
   object-fit: cover;
 }

--- a/src/containers/PageBuilder/Primitives/P/P.js
+++ b/src/containers/PageBuilder/Primitives/P/P.js
@@ -16,10 +16,11 @@ P.displayName = 'P';
 P.defaultProps = {
   rootClassName: null,
   className: null,
+  children: null,
 };
 
 P.propTypes = {
   rootClassName: string,
   className: string,
-  children: node.isRequired,
+  children: node,
 };

--- a/src/containers/PrivacyPolicyPage/PrivacyPolicyPage.js
+++ b/src/containers/PrivacyPolicyPage/PrivacyPolicyPage.js
@@ -2,10 +2,9 @@ import React from 'react';
 import { bool, object } from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 
-import { injectIntl, intlShape } from '../../util/reactIntl';
 import { camelize } from '../../util/string';
+import { propTypes } from '../../util/types';
 
 import { H1 } from '../PageBuilder/Primitives/Heading';
 import PageBuilder, { SectionBuilder } from '../../containers/PageBuilder/PageBuilder';
@@ -47,27 +46,27 @@ const PrivacyPolicyContent = props => {
 
 // Presentational component for PrivacyPolicyPage
 const PrivacyPolicyPageComponent = props => {
-  const { pageAssetsData, inProgress } = props;
+  const { pageAssetsData, inProgress, error } = props;
 
   return (
     <PageBuilder
       pageAssetsData={pageAssetsData?.[camelize(ASSET_NAME)]?.data}
       inProgress={inProgress}
+      error={error}
       fallbackPage={<FallbackPage />}
     />
   );
 };
 
 PrivacyPolicyPageComponent.propTypes = {
-  // from injectIntl
-  intl: intlShape.isRequired,
   pageAssetsData: object,
   inProgress: bool,
+  error: propTypes.error,
 };
 
 const mapStateToProps = state => {
-  const { pageAssetsData, inProgress } = state.hostedAssets || {};
-  return { pageAssetsData, inProgress };
+  const { pageAssetsData, inProgress, error } = state.hostedAssets || {};
+  return { pageAssetsData, inProgress, error };
 };
 
 // Note: it is important that the withRouter HOC is **outside** the
@@ -76,11 +75,7 @@ const mapStateToProps = state => {
 // lifecycle hook.
 //
 // See: https://github.com/ReactTraining/react-router/issues/4671
-const PrivacyPolicyPage = compose(
-  withRouter,
-  connect(mapStateToProps),
-  injectIntl
-)(PrivacyPolicyPageComponent);
+const PrivacyPolicyPage = compose(connect(mapStateToProps))(PrivacyPolicyPageComponent);
 
 const PRIVACY_POLICY_ASSET_NAME = ASSET_NAME;
 export { PRIVACY_POLICY_ASSET_NAME, PrivacyPolicyPageComponent, PrivacyPolicyContent };

--- a/src/containers/TermsOfServicePage/TermsOfServicePage.js
+++ b/src/containers/TermsOfServicePage/TermsOfServicePage.js
@@ -2,10 +2,9 @@ import React from 'react';
 import { bool, object } from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 
-import { injectIntl, intlShape } from '../../util/reactIntl';
 import { camelize } from '../../util/string';
+import { propTypes } from '../../util/types';
 
 import { H1 } from '../PageBuilder/Primitives/Heading';
 import PageBuilder, { SectionBuilder } from '../../containers/PageBuilder/PageBuilder';
@@ -47,27 +46,27 @@ const TermsOfServiceContent = props => {
 
 // Presentational component for TermsOfServicePage
 const TermsOfServicePageComponent = props => {
-  const { pageAssetsData, inProgress } = props;
+  const { pageAssetsData, inProgress, error } = props;
 
   return (
     <PageBuilder
       pageAssetsData={pageAssetsData?.[camelize(ASSET_NAME)]?.data}
       inProgress={inProgress}
+      error={error}
       fallbackPage={<FallbackPage />}
     />
   );
 };
 
 TermsOfServicePageComponent.propTypes = {
-  // from injectIntl
-  intl: intlShape.isRequired,
   pageAssetsData: object,
   inProgress: bool,
+  error: propTypes.error,
 };
 
 const mapStateToProps = state => {
-  const { pageAssetsData, inProgress } = state.hostedAssets || {};
-  return { pageAssetsData, inProgress };
+  const { pageAssetsData, inProgress, error } = state.hostedAssets || {};
+  return { pageAssetsData, inProgress, error };
 };
 
 // Note: it is important that the withRouter HOC is **outside** the
@@ -76,11 +75,7 @@ const mapStateToProps = state => {
 // lifecycle hook.
 //
 // See: https://github.com/ReactTraining/react-router/issues/4671
-const TermsOfServicePage = compose(
-  withRouter,
-  connect(mapStateToProps),
-  injectIntl
-)(TermsOfServicePageComponent);
+const TermsOfServicePage = compose(connect(mapStateToProps))(TermsOfServicePageComponent);
 
 const TOS_ASSET_NAME = ASSET_NAME;
 export { TOS_ASSET_NAME, TermsOfServicePageComponent, TermsOfServiceContent };


### PR DESCRIPTION
## [Changes] v10.1.0

- [change] remove the `background-color` from images (to allow opacity) and don't stretch small markdown images.
  [#1590](https://github.com/sharetribe/ftw-daily/pull/1590)
- [change] improve error handling possibilities on PageBuilder.
  [#1589](https://github.com/sharetribe/ftw-daily/pull/1589)
- [fix] **AuthenticationPage.duck.js: had wrong asset name for _terms-of-service.json_**
  [#1588](https://github.com/sharetribe/ftw-daily/pull/1588)
- [change] P.js: remove the requirement for mandatory children.
  [#1587](https://github.com/sharetribe/ftw-daily/pull/1587)


  [Changes]: https://github.com/sharetribe/ftw-daily/compare/v10.0.0.../v10.1.0
